### PR TITLE
Fixed errors caused by no files

### DIFF
--- a/src/transformer/index.ts
+++ b/src/transformer/index.ts
@@ -78,6 +78,7 @@ export default function (program: ts.Program, host: ts.CompilerHost | undefined)
     }
     host.getSourceFile = fileName => {
         const file = result.find(x => x.fileName === fileName);
+        if(!file) return;
         const updated = ts.updateSourceFileNode(file, [...file.statements]);
         if (!updated["ambientModuleNames"]) {
             updated["ambientModuleNames"] = updated["original"]["ambientModuleNames"] ?? [];


### PR DESCRIPTION
Fix error by: TypeError: Cannot read properties of undefined (reading 'statements')